### PR TITLE
Added Per-Plane NPC/Player ignore override settings to "Ai Enabler" tool

### DIFF
--- a/lua/entities/lunasflightschool_basescript/init.lua
+++ b/lua/entities/lunasflightschool_basescript/init.lua
@@ -1699,14 +1699,14 @@ function ENT:AIGetTarget()
 		end
 	end
 
-	local shouldTargetNpcs = false
+	local shouldIgnoreNpcs = false
 	if self.IgnoreNpcsOverride ~= nil then
-    	shouldTargetNpcs = self.IgnoreNpcsOverride
+    	shouldIgnoreNpcs = self.IgnoreNpcsOverride
 	else
-    	shouldTargetNpcs = simfphys.LFS.IgnoreNPCs
+    	shouldIgnoreNpcs = simfphys.LFS.IgnoreNPCs
 	end
 
-	if not shouldTargetNpcs then
+	if not shouldIgnoreNpcs then
 		for _, v in pairs( self:AIGetNPCTargets() ) do
 			if IsValid( v ) then
 				local HisTeam = self:AIGetNPCRelationship( v:GetClass() )

--- a/lua/entities/lunasflightschool_basescript/init.lua
+++ b/lua/entities/lunasflightschool_basescript/init.lua
@@ -1657,7 +1657,14 @@ function ENT:AIGetTarget()
 	local ClosestTarget = NULL
 	local TargetDistance = 60000
 
-	if not simfphys.LFS.IgnorePlayers then
+	local shouldIgnorePlayers = false
+	if self.IgnorePlayersOverride ~= nil then
+		shouldIgnorePlayers = self.IgnorePlayersOverride
+	else
+		shouldIgnorePlayers = simfphys.LFS.IgnorePlayers
+	end
+
+	if not shouldIgnorePlayers then
 		for _, v in pairs( players ) do
 			if IsValid( v ) then
 				if v:Alive() then
@@ -1692,7 +1699,14 @@ function ENT:AIGetTarget()
 		end
 	end
 
-	if not simfphys.LFS.IgnoreNPCs then
+	local shouldTargetNpcs = false
+	if self.IgnoreNpcsOverride ~= nil then
+    	shouldTargetNpcs = self.IgnoreNpcsOverride
+	else
+    	shouldTargetNpcs = simfphys.LFS.IgnoreNPCs
+	end
+
+	if not shouldTargetNpcs then
 		for _, v in pairs( self:AIGetNPCTargets() ) do
 			if IsValid( v ) then
 				local HisTeam = self:AIGetNPCRelationship( v:GetClass() )

--- a/lua/entities/lunasflightschool_basescript/init.lua
+++ b/lua/entities/lunasflightschool_basescript/init.lua
@@ -1701,9 +1701,9 @@ function ENT:AIGetTarget()
 
 	local shouldIgnoreNpcs = false
 	if self.IgnoreNpcsOverride ~= nil then
-    	shouldIgnoreNpcs = self.IgnoreNpcsOverride
+		shouldIgnoreNpcs = self.IgnoreNpcsOverride
 	else
-    	shouldIgnoreNpcs = simfphys.LFS.IgnoreNPCs
+		shouldIgnoreNpcs = simfphys.LFS.IgnoreNPCs
 	end
 
 	if not shouldIgnoreNpcs then

--- a/lua/weapons/gmod_tool/stools/lfsaienabler.lua
+++ b/lua/weapons/gmod_tool/stools/lfsaienabler.lua
@@ -54,7 +54,7 @@ function TOOL:Think()
 	local ent = tr.Entity
 	if not IsValid( ent ) or not ent.LFS then return end
 
-	local text = "LFS Team: " .. tostring( ent:GetAITEAM() ) .. tostring(ent.IgnoreNpcsOverride)
+	local text = "LFS Team: " .. tostring( ent:GetAITEAM() )
 
 	AddWorldTip( ent:EntIndex(), text, SysTime() + 0.05, ent:GetPos(), ent )
 end

--- a/lua/weapons/gmod_tool/stools/lfsaienabler.lua
+++ b/lua/weapons/gmod_tool/stools/lfsaienabler.lua
@@ -66,7 +66,7 @@ function TOOL.BuildCPanel( panel )
 	cbox:AddChoice( "2 - Friendly to team 2 and 0, hostile to everything else", 2 )
 	cbox:AddChoice( "3 - Hostile to everyone", 3 )
 
-	local npcchbox = panel:CheckBox( "Ignore NPCS", "lfsaienabler_ignorenpcs" )
-	local playerchbox = panel:CheckBox( "Ignore Players", "lfsaienabler_ignoreplayers" )
+	panel:CheckBox( "Ignore NPCS", "lfsaienabler_ignorenpcs" )
+	panel:CheckBox( "Ignore Players", "lfsaienabler_ignoreplayers" )
 
 end

--- a/lua/weapons/gmod_tool/stools/lfsaienabler.lua
+++ b/lua/weapons/gmod_tool/stools/lfsaienabler.lua
@@ -4,6 +4,8 @@ TOOL.Name	 = "#AI Enabler"
 TOOL.Command = nil
 TOOL.ConfigName = ""
 TOOL.ClientConVar["aiteam"] = 0
+TOOL.ClientConVar["ignorenpcs"] = 0
+TOOL.ClientConVar["ignoreplayers"] = 0
 
 if CLIENT then
 	language.Add( "tool.lfsaienabler.name", "AI Enabler" )
@@ -20,6 +22,8 @@ function TOOL:LeftClick( trace )
 	if isfunction( ent.SetAI ) then
 		ent:SetAI( true )
 		ent:SetAITEAM( self:GetClientNumber( "aiteam" ) )
+		ent.IgnoreNpcsOverride = self:GetClientBool( "ignorenpcs" )
+		ent.IgnorePlayersOverride = self:GetClientBool( "ignoreplayers" )
 	end
 
 	return true
@@ -50,7 +54,7 @@ function TOOL:Think()
 	local ent = tr.Entity
 	if not IsValid( ent ) or not ent.LFS then return end
 
-	local text = "LFS Team: " .. tostring( ent:GetAITEAM() )
+	local text = "LFS Team: " .. tostring( ent:GetAITEAM() ) .. tostring(ent.IgnoreNpcsOverride)
 
 	AddWorldTip( ent:EntIndex(), text, SysTime() + 0.05, ent:GetPos(), ent )
 end
@@ -61,4 +65,8 @@ function TOOL.BuildCPanel( panel )
 	cbox:AddChoice( "1 - Friendly to team 1 and 0, hostile to everything else", 1 )
 	cbox:AddChoice( "2 - Friendly to team 2 and 0, hostile to everything else", 2 )
 	cbox:AddChoice( "3 - Hostile to everyone", 3 )
+
+	local npcchbox = panel:CheckBox( "Ignore NPCS", "lfsaienabler_ignorenpcs" )
+	local playerchbox = panel:CheckBox( "Ignore Players", "lfsaienabler_ignoreplayers" )
+
 end


### PR DESCRIPTION
Lets those who use the AI Enabler tool to edit whether or not a plane AI ignores NPCs or players