### PR TITLE
Tweaks

### DIFF
--- a/lua/entities/lunasflightschool_missile.lua
+++ b/lua/entities/lunasflightschool_missile.lua
@@ -65,12 +65,11 @@ if SERVER then
 	end
 
 	function ENT:FollowTarget( followent )
-
 		-- increase turnrate the longer missile is alive, bear down on far targets.
 		-- goal is to punish pilots/drivers who camp far away from players.
 		local timeAlive = math.abs( self:GetCreationTime() - CurTime() )
-		local turnrateAdd = math.Clamp( timeAlive * 75, 0, 500 ) * lfsRpgMobilityMul:GetFloat()
-		local speedAdd = math.Clamp( timeAlive * 400, 0, 5000 ) * lfsRpgMobilityMul:GetFloat()
+		local turnrateAdd = math.Clamp( timeAlive * 75, 0, 350 ) * lfsRpgMobilityMul:GetFloat()
+		local speedAdd = math.Clamp( timeAlive * 400, 0, 10000 ) * lfsRpgMobilityMul:GetFloat()
 
 		local speed = self:GetStartVelocity() + ( self:GetDirtyMissile() and 4000 or 2500 )
 		speed = speed + speedAdd
@@ -103,7 +102,7 @@ if SERVER then
 			local targetdir = subtractionProduct:GetNormalized()
 
 			local AF = self:WorldToLocalAngles( targetdir:Angle() )
-			local badAngles = AF.p > 110 or AF.y > 110
+			local badAngles = AF.p > 100 or AF.y > 100
 
 			if distToTargSqr < 500^2 then
 				self:DoHitTrace( myPos )

--- a/lua/entities/lunasflightschool_missile.lua
+++ b/lua/entities/lunasflightschool_missile.lua
@@ -104,10 +104,10 @@ if SERVER then
 			local AF = self:WorldToLocalAngles( targetdir:Angle() )
 			local badAngles = AF.p > 100 or AF.y > 100
 
-			if distToTargSqr < 500^2 then
-				self:DoHitTrace( myPos )
-			-- target is cheating! they're no collided!
+			if distToTargSqr < 500^2 and self:DoHitTrace( myPos ) then
+				return
 			-- if you want to make a plane/vehicle not get targeted by LFS missilelauncher then see LFS.RPGBlockLockon hook, in the launcher
+			-- target is cheating! they're no collided!
 			elseif distToTargSqr < 75^2 then
 				self:HitEntity( followent )
 				return
@@ -122,6 +122,7 @@ if SERVER then
 			AF.r = math.Clamp( AF.r * 400,-turnrate,turnrate )
 
 			local AVel = pObj:GetAngleVelocity()
+			if not IsValid( pObj ) then return end
 			pObj:AddAngleVelocity( Vector( AF.r,AF.p,AF.y ) - AVel )
 
 			pObj:SetVelocityInstantaneous( self:GetForward() * speed )

--- a/lua/entities/lunasflightschool_missile.lua
+++ b/lua/entities/lunasflightschool_missile.lua
@@ -298,6 +298,8 @@ else
 		self.snd = CreateSound( self, "weapons/flaregun/burn.wav" )
 		self.snd:Play()
 
+		-- make trail effect on client init
+		-- very very unreliable on server init
 		local effectdata = EffectData()
 			effectdata:SetOrigin( self:GetPos() )
 			effectdata:SetEntity( self )

--- a/lua/weapons/weapon_lfsmissilelauncher.lua
+++ b/lua/weapons/weapon_lfsmissilelauncher.lua
@@ -249,7 +249,15 @@ function SWEP:PrimaryAttack()
 end
 
 function SWEP:SecondaryAttack()
-	return false
+	if not IsValid( self:GetClosestEnt() ) then return false end
+	if not IsFirstTimePredicted() then return end
+	self:SetNextSecondaryFire( CurTime() + 0.5 )
+	if CLIENT then
+		self:EmitSound( "buttons/lightswitch2.wav", 75, math.random( 150, 175 ), 0.25 )
+
+	else
+		self:UnLock()
+	end
 end
 
 function SWEP:Deploy()
@@ -260,8 +268,6 @@ end
 function SWEP:Reload()
 	if self:Clip1() < self.Primary.ClipSize and self:GetOwner():GetAmmoCount( self.Primary.Ammo ) > 0 then
 		self:DefaultReload( ACT_VM_RELOAD )
-		self:UnLock()
-	else
 		self:UnLock()
 	end
 end

--- a/lua/weapons/weapon_lfsmissilelauncher.lua
+++ b/lua/weapons/weapon_lfsmissilelauncher.lua
@@ -44,6 +44,7 @@ end
 
 local lfsRpgLockTime
 local lfsRpgLockAngle
+local lfsRpgMaxLockRange = CreateConVar( "lfs_rpgmaxrange", 60000, { FCVAR_ARCHIVE, FCVAR_REPLICATED } )
 if SERVER then
 	lfsRpgLockTime = CreateConVar( "lfs_rpglocktime", 3, FCVAR_ARCHIVE )
 	lfsRpgLockAngle = CreateConVar( "lfs_rpglockangle", 15, FCVAR_ARCHIVE )
@@ -128,6 +129,9 @@ function SWEP:Think()
 		local AimForward = Owner:GetAimVector()
 		local startpos = Owner:GetShootPos()
 
+		local maxDist = lfsRpgMaxLockRange:GetInt()
+		local lockOnAng = lfsRpgLockAngle:GetInt()
+
 		local Vehicles = {}
 		local ClosestEnt = NULL
 		local ClosestDist = math.huge
@@ -143,12 +147,14 @@ function SWEP:Think()
 			local toEnt = sub:GetNormalized()
 			local Ang = math.acos( math.Clamp( AimForward:Dot( toEnt ), -1, 1 ) ) * ( 180 / math.pi )
 
-			if Ang >= lfsRpgLockAngle:GetInt() or not self:CanSee( vehicle, Owner ) then continue end
+			if Ang >= lockOnAng or not self:CanSee( vehicle, Owner ) then continue end
 
 			table.insert( Vehicles, vehicle )
 
 			local stuff = WorldToLocal( vehicle:GetPos(), Angle( 0, 0, 0 ), startpos, Owner:EyeAngles() + Angle( 90, 0, 0 ) )
 			local dist = stuff:Length()
+
+			if dist > maxDist then continue end
 
 			 -- only switch when much closer!
 			if dist < ClosestDist and Ang < SmallestAng then
@@ -255,6 +261,8 @@ function SWEP:Reload()
 	if self:Clip1() < self.Primary.ClipSize and self:GetOwner():GetAmmoCount( self.Primary.Ammo ) > 0 then
 		self:DefaultReload( ACT_VM_RELOAD )
 		self:UnLock()
+	else
+		self:UnLock()
 	end
 end
 
@@ -301,6 +309,7 @@ local function PaintPlaneIdentifier( ply )
 	local MyPos = ply:GetPos()
 	local MyTeam = ply:lfsGetAITeam()
 	local startpos = ply:GetShootPos()
+	local maxDist = lfsRpgMaxLockRange:GetInt()
 
 	for _, vehicle in pairs( AllPlanes ) do
 		if not IsValid( vehicle ) then continue end
@@ -309,6 +318,8 @@ local function PaintPlaneIdentifier( ply )
 
 		local Pos = rPos:ToScreen()
 		local Dist = ( MyPos - rPos ):Length()
+		if Dist > maxDist then continue end
+
 		if util.TraceLine( { start = startpos,endpos = rPos,mask = MASK_NPCWORLDSTATIC } ).Hit then continue end
 
 		local Alpha = math.max( 255 - Dist * 0.015, 0 )


### PR DESCRIPTION
Decrease max turnrate based off observations from playtesting.
Make the missile "Lose target" easier based off playtesting.

Add lfs_rpgmaxrange convar.
Defines how far away the missile can lock onto targets.

Add feature, press Reload to stop locking onto a target.
