### PR TITLE
Add Hook for Leaving LFS Vehicles

### DIFF
--- a/lua/autorun/lfs_basescript.lua
+++ b/lua/autorun/lfs_basescript.lua
@@ -441,7 +441,7 @@ if SERVER then
                 ply:lfsSetInput( LFS_BIND[button], true )
 
                 if IsValid( vehicle ) and ply.LFS_HIPSTER and LFS_BIND[button] == "EXIT" then
-                    if hook.Run( "LFS.OnPlayerRequestLeaveVehicle", vehicle, ply ) ~= false then
+                    if hook.Run( "LFS.CanPlayerLeaveVehicle", vehicle, ply ) ~= false then
                         timer.Simple( 0, function()
                             ply:ExitVehicle()
                         end)

--- a/lua/autorun/lfs_basescript.lua
+++ b/lua/autorun/lfs_basescript.lua
@@ -440,13 +440,11 @@ if SERVER then
             if LFS_BIND[button] then
                 ply:lfsSetInput( LFS_BIND[button], true )
 
-                if IsValid( vehicle ) then
-                    if ply.LFS_HIPSTER then
-                        if LFS_BIND[button] == "EXIT" then
-                            timer.Simple( 0, function()
-                                ply:ExitVehicle()
-                            end )
-                        end
+                if IsValid( vehicle ) and ply.LFS_HIPSTER and LFS_BIND[button] == "EXIT" then
+                    if hook.Run( "LFS.OnPlayerRequestLeaveVehicle", vehicle, ply ) ~= false then
+                        timer.Simple( 0, function()
+                            ply:ExitVehicle()
+                        end)
                     end
                 end
             end


### PR DESCRIPTION
## Description
Adds the ability to prevent a player from leaving a LFS Vehicle as LFS uses `meta:ExitVehicle()` which bypasses the `CanExitVehicle` hook.

## Dev Notes
Combined the triple if statement as well.


## Checklist
<!-- Please check these boxes off to indicate the status of your PR -->
 - [x] This PR has been tested on a non-p2p server and confirmed to be working
